### PR TITLE
Update nom from v7 to v8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ bytes = "1.9"
 fletcher = "1.0.0"
 hex = "0.4.3"
 ipnet = { version = "2.10", features = ["serde"] }
-nom = "7"
-nom-derive = "0.10"
+nom = "8"
+nom-derive = { git = "https://github.com/rust-bakery/nom-derive", branch = "master" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 


### PR DESCRIPTION
## Summary
- Update nom dependency from 7 to 8
- Use nom-derive 0.11.0 from GitHub master branch (supports nom 8)
- All tests pass without code changes

## Test plan
- [x] Run cargo build - builds successfully
- [x] Run cargo test - all tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)