### PR TITLE
Update hex-literal from v0.3 to v1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,4 +33,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 
 [dev-dependencies]
-hex-literal = "0.3"
+hex-literal = "1.0"


### PR DESCRIPTION
## Summary
- Update hex-literal dev dependency from 0.3 to 1.0
- All tests pass without code changes

## Test plan
- [x] Run cargo build - builds successfully
- [x] Run cargo test - all tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)